### PR TITLE
Dont tile query

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,7 @@
   <!-- Mapbox GL Extensions -->
   <script src='https://cdn.jsdelivr.net/gh/publicmap/mapbox-gl-tools@master/dist/addMapControls.js'></script>
   <link href='https://cdn.jsdelivr.net/gh/publicmap/mapbox-gl-tools@master/dist/addMapControls.css' rel='stylesheet'>
-  <!-- jQuery -->
-  <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+
   <style>
     body,
     input,

--- a/js/add-style-layers.js
+++ b/js/add-style-layers.js
@@ -7,8 +7,6 @@ function addStyleLayers(map) {
     map.setPaintProperty('pc line border-highlight', 'line-color', [
         "match", ["feature-state", "state"], 'active',
         "hsl(62, 97%, 61%)",
-        "match", ["feature-state", "state"], 'hover',
-        "hsl(62, 97%, 61%)",
         "hsl(22, 98%, 92%)"
     ])
 

--- a/js/dist/index.js
+++ b/js/dist/index.js
@@ -46,8 +46,6 @@ function addStyleLayers(map) {
     map.setPaintProperty('pc line border-highlight', 'line-color', [
         "match", ["feature-state", "state"], 'active',
         "hsl(62, 97%, 61%)",
-        "match", ["feature-state", "state"], 'hover',
-        "hsl(62, 97%, 61%)",
         "hsl(22, 98%, 92%)"
     ])
 
@@ -172,10 +170,51 @@ map.on('load', () => {
 
   map.on('click', 'pc fill mask', (e) => {
 
+    // Package the features at clicked location to resemble a tilequery result
+    e.tileFeatures = {
+      'ac': {},
+      'pc': e.features[0],
+      'schedule': {}
+    }
+
     // Show constituency details at location
     showDataAtPoint(map, e)
 
   })
+
+  // // Add hover effect on mouseover
+  // var hoveredFeatureId = null;
+  // map.on('mousemove', 'pc fill mask', (e) => {
+
+  //   if (e.features[0].id != hoveredFeatureId) {
+
+  //     var currentState = map.getFeatureState({
+  //       source: 'mapbox://planemad.3picr4b8',
+  //       sourceLayer: 'pc',
+  //       id: e.features[0].id
+  //     })['state']
+
+  //     if (currentState != 'active') {
+
+  //       map.removeFeatureState({
+  //         source: 'mapbox://planemad.3picr4b8',
+  //         sourceLayer: 'pc',
+  //         id: hoveredFeatureId
+  //       }, 'state');
+
+  //       map.setFeatureState({
+  //         source: 'mapbox://planemad.3picr4b8',
+  //         sourceLayer: 'pc',
+  //         id: e.features[0].id
+  //       }, {
+  //         state: 'hover'
+  //       });
+
+  //       hoveredFeatureId = e.features[0].id;
+
+  //     }
+  //   }
+  // })
 
 });
 },{"./add-style-layers":3,"./addMapControls":4,"./locate-user":7,"./show-data-at-point":9}],7:[function(require,module,exports){
@@ -300,64 +339,92 @@ require('./object-assign-polyfill')
 
 module.exports = showDataAtPoint
 
-function showDataAtPoint (map, e) {
+function showDataAtPoint(map, e) {
+
+
+  // Query rendered features at clicked point
+  var features = map.queryRenderedFeatures(e.point, {
+    layers: ['pc fill mask']
+  })
+  console.log(features)
+  console.log(e.point)
 
   // Add marker at clicked location
   Markers.addMarker(map, e);
-  
+
   const tilequeryURL = getTilequeryURL(e.lngLat)
 
   map.flyTo({
     center: [e.lngLat.lng, e.lngLat.lat]
   })
 
+  // If event object has tile features from clicked event, use it to update the info panel
+  // Else fetch the features at that point using the tilequery API
+  if (e.tileFeatures != undefined) {
+    updateInfoPanel(map, e.tileFeatures);
+  } else {
+    // use fetch to fetch data - this maintains consistency with using fetch elsewhere
+    // if we have browser considerations where `fetch` does not work,
+    // we can replace this with $.getJSON or so
+    fetch(tilequeryURL)
+      .then(response => response.json())
+      .then(data => {
+
+        // merge the damn properies
+        // var holder = Object.assign({}, data.features[0].properties, data.features[1].properties);
+
+        var tileFeatures = {}
+        data.features.forEach(feature => {
+          tileFeatures[feature.properties.tilequery.layer] = feature;
+        });
+
+        updateInfoPanel(map, tileFeatures);
+
+      })
+      .catch(err => {
+        document.getElementById('infoPanel').classList.remove('loading');
+        document.getElementById('infoPanel').innerHTML = `Error while fetching data for that location`;
+      })
+  }
+}
+
+var activeFeatureId = null;
+
+function updateInfoPanel(map, tileFeatures) {
+
+  console.log('Constituency details API:', tileFeatures);
+
   // Add a loading spinner to the infoPanel while we fetch data
   document.getElementById('infoPanel').innerHTML = '';
-  document.getElementById('infoPanel').classList.add('loading','loading--s');
+  document.getElementById('infoPanel').classList.add('loading', 'loading--s');
 
+  var ECI_code = ECILookup[String(tileFeatures.pc.properties.st_code)]['ECI_code'];
 
-  // use fetch to fetch data - this maintains consistency with using fetch elsewhere
-  // if we have browser considerations where `fetch` does not work,
-  // we can replace this with $.getJSON or so
-  fetch(tilequeryURL)
-    .then(response => response.json())
-    .then(data => {
-      // merge the damn properies
-      var holder = Object.assign({}, data.features[0].properties, data.features[1].properties);
-      console.log('Constituency details API:',holder);
+  // Composing link to Official ECI candidates affidavits page: https://affidavit.eci.gov.in/showaffidavit/1/S13/34/PC
+  var ECIAffidavit_URL = `https://affidavit.eci.gov.in/showaffidavit/1/${ECI_code}/${String(tileFeatures.pc.properties.pc_no)}/PC`;
 
-      var ECI_code = ECILookup[String(holder.st_code)]['ECI_code'];
+  // Composing info
+  var info = `<span class='txt-light'>2019 Lok Sabha Elections</span><br>
+    <span class='txt-light'>Your Constituency: </span><b>${tileFeatures.pc.properties.pc_name}</b> (${tileFeatures.pc.properties.pc_no})<br>
+    <span class='txt-light'>Voting is on: </span><b>${tileFeatures.pc.properties['2019_election_date'].split('T')[0]}</b> (Phase ${tileFeatures.pc.properties['2019_election_phase']})<br>
+    <a href="${ECIAffidavit_URL}" target="_blank" class="link">Click here to see the Candidates</a> <br>
+    State: ${tileFeatures.pc.properties.st_name} (${ECI_code})<br>
+    `;
+  document.getElementById('infoPanel').classList.remove('loading');
+  document.getElementById('infoPanel').innerHTML = info;
 
-      // Composing link to Official ECI candidates affidavits page: https://affidavit.eci.gov.in/showaffidavit/1/S13/34/PC
-      var ECIAffidavit_URL = `https://affidavit.eci.gov.in/showaffidavit/1/${ECI_code}/${String(holder.pc_no)}/PC`;
+  // Clear previous and set the feature-state of the selected constieuncy feature id in the style layer as 'active'
+  map.removeFeatureState({
+    source: 'mapbox://planemad.3picr4b8',
+    sourceLayer: 'pc'
+  });
+  map.setFeatureState({
+    source: 'mapbox://planemad.3picr4b8',
+    sourceLayer: 'pc',
+    id: tileFeatures.pc.id
+  }, {
+    state: 'active'
+  });
 
-      // Composing info
-      var info = `<span class='txt-light'>2019 Lok Sabha Elections</span><br>
-      <span class='txt-light'>Your Constituency: </span><b>${holder.pc_name}</b> (${holder.pc_no})<br>
-      <span class='txt-light'>Voting is on: </span><b>${holder['2019_election_date'].split('T')[0]}</b> (Phase ${holder['2019_election_phase']})<br>
-      <a href="${ECIAffidavit_URL}" target="_blank" class="link">Click here to see the Candidates</a> <br>
-      State: ${holder.st_name} (${ECI_code})<br>
-      `;
-      document.getElementById('infoPanel').classList.remove('loading');
-      document.getElementById('infoPanel').innerHTML = info;
-
-      // Clear previous and set the feature-state of the selected constieuncy feature id in the style layer as 'active'
-      map.removeFeatureState({
-        source: 'mapbox://planemad.3picr4b8',
-        sourceLayer: 'pc'
-      });
-      map.setFeatureState({
-        source: 'mapbox://planemad.3picr4b8',
-        sourceLayer: 'pc',
-        id: data.features[1].id
-      }, {
-        state: 'active'
-      });
-
-    })
-    .catch(err => {
-      document.getElementById('infoPanel').classList.remove('loading');
-      document.getElementById('infoPanel').innerHTML = `Error while fetching data for that location`;
-    })
 }
 },{"./ECILookup":1,"./add-marker":2,"./get-tilequery-url":5,"./object-assign-polyfill":8}]},{},[6]);

--- a/js/index.js
+++ b/js/index.js
@@ -51,4 +51,39 @@ map.on('load', () => {
 
   })
 
+
+  // Add hover effect on mouseover
+  var hoveredFeatureId = null;
+  map.on('mousemove', 'pc fill mask', (e) => {
+
+    if ( e.features[0].id != hoveredFeatureId ){
+
+      map.removeFeatureState({
+        source: 'mapbox://planemad.3picr4b8',
+        sourceLayer: 'pc',
+        id: hoveredFeatureId
+      },'state');
+
+      var currentState = map.getFeatureState({
+        source: 'mapbox://planemad.3picr4b8',
+        sourceLayer: 'pc',
+        id: e.features[0].id
+      })['state']
+
+        if ( currentState != 'active'){
+
+        map.setFeatureState({
+          source: 'mapbox://planemad.3picr4b8',
+          sourceLayer: 'pc',
+          id: e.features[0].id
+        }, {
+          state: 'hover'
+        });
+
+        hoveredFeatureId = e.features[0].id;
+
+      }
+    }
+  })
+
 });

--- a/js/index.js
+++ b/js/index.js
@@ -46,44 +46,50 @@ map.on('load', () => {
 
   map.on('click', 'pc fill mask', (e) => {
 
+    // Package the features at clicked location to resemble a tilequery result
+    e.tileFeatures = {
+      'ac': {},
+      'pc': e.features[0],
+      'schedule': {}
+    }
+
     // Show constituency details at location
     showDataAtPoint(map, e)
 
   })
 
+  // // Add hover effect on mouseover
+  // var hoveredFeatureId = null;
+  // map.on('mousemove', 'pc fill mask', (e) => {
 
-  // Add hover effect on mouseover
-  var hoveredFeatureId = null;
-  map.on('mousemove', 'pc fill mask', (e) => {
+  //   if (e.features[0].id != hoveredFeatureId) {
 
-    if ( e.features[0].id != hoveredFeatureId ){
+  //     var currentState = map.getFeatureState({
+  //       source: 'mapbox://planemad.3picr4b8',
+  //       sourceLayer: 'pc',
+  //       id: e.features[0].id
+  //     })['state']
 
-      map.removeFeatureState({
-        source: 'mapbox://planemad.3picr4b8',
-        sourceLayer: 'pc',
-        id: hoveredFeatureId
-      },'state');
+  //     if (currentState != 'active') {
 
-      var currentState = map.getFeatureState({
-        source: 'mapbox://planemad.3picr4b8',
-        sourceLayer: 'pc',
-        id: e.features[0].id
-      })['state']
+  //       map.removeFeatureState({
+  //         source: 'mapbox://planemad.3picr4b8',
+  //         sourceLayer: 'pc',
+  //         id: hoveredFeatureId
+  //       }, 'state');
 
-        if ( currentState != 'active'){
+  //       map.setFeatureState({
+  //         source: 'mapbox://planemad.3picr4b8',
+  //         sourceLayer: 'pc',
+  //         id: e.features[0].id
+  //       }, {
+  //         state: 'hover'
+  //       });
 
-        map.setFeatureState({
-          source: 'mapbox://planemad.3picr4b8',
-          sourceLayer: 'pc',
-          id: e.features[0].id
-        }, {
-          state: 'hover'
-        });
+  //       hoveredFeatureId = e.features[0].id;
 
-        hoveredFeatureId = e.features[0].id;
-
-      }
-    }
-  })
+  //     }
+  //   }
+  // })
 
 });

--- a/js/show-data-at-point.js
+++ b/js/show-data-at-point.js
@@ -7,13 +7,10 @@ module.exports = showDataAtPoint
 
 function showDataAtPoint(map, e) {
 
-
   // Query rendered features at clicked point
   var features = map.queryRenderedFeatures(e.point, {
     layers: ['pc fill mask']
   })
-  console.log(features)
-  console.log(e.point)
 
   // Add marker at clicked location
   Markers.addMarker(map, e);

--- a/js/show-data-at-point.js
+++ b/js/show-data-at-point.js
@@ -5,70 +5,91 @@ require('./object-assign-polyfill')
 
 module.exports = showDataAtPoint
 
-function showDataAtPoint (map, e) {
+function showDataAtPoint(map, e) {
 
 
-    // Query rendered features at clicked point
-    var features = map.queryRenderedFeatures(e.point,{layers:['pc fill mask']})
-    console.log(features)
-    console.log(e.point)
+  // Query rendered features at clicked point
+  var features = map.queryRenderedFeatures(e.point, {
+    layers: ['pc fill mask']
+  })
+  console.log(features)
+  console.log(e.point)
 
   // Add marker at clicked location
   Markers.addMarker(map, e);
-  
+
   const tilequeryURL = getTilequeryURL(e.lngLat)
 
   map.flyTo({
     center: [e.lngLat.lng, e.lngLat.lat]
   })
 
+  // If event object has tile features from clicked event, use it to update the info panel
+  // Else fetch the features at that point using the tilequery API
+  if (e.tileFeatures != undefined) {
+    updateInfoPanel(map, e.tileFeatures);
+  } else {
+    // use fetch to fetch data - this maintains consistency with using fetch elsewhere
+    // if we have browser considerations where `fetch` does not work,
+    // we can replace this with $.getJSON or so
+    fetch(tilequeryURL)
+      .then(response => response.json())
+      .then(data => {
+
+        // merge the damn properies
+        // var holder = Object.assign({}, data.features[0].properties, data.features[1].properties);
+
+        var tileFeatures = {}
+        data.features.forEach(feature => {
+          tileFeatures[feature.properties.tilequery.layer] = feature;
+        });
+
+        updateInfoPanel(map, tileFeatures);
+
+      })
+      .catch(err => {
+        document.getElementById('infoPanel').classList.remove('loading');
+        document.getElementById('infoPanel').innerHTML = `Error while fetching data for that location`;
+      })
+  }
+}
+
+var activeFeatureId = null;
+
+function updateInfoPanel(map, tileFeatures) {
+
+  console.log('Constituency details API:', tileFeatures);
+
   // Add a loading spinner to the infoPanel while we fetch data
   document.getElementById('infoPanel').innerHTML = '';
-  document.getElementById('infoPanel').classList.add('loading','loading--s');
+  document.getElementById('infoPanel').classList.add('loading', 'loading--s');
 
+  var ECI_code = ECILookup[String(tileFeatures.pc.properties.st_code)]['ECI_code'];
 
-  // use fetch to fetch data - this maintains consistency with using fetch elsewhere
-  // if we have browser considerations where `fetch` does not work,
-  // we can replace this with $.getJSON or so
-  fetch(tilequeryURL)
-    .then(response => response.json())
-    .then(data => {
-      
-      // merge the damn properies
-      var holder = Object.assign({}, data.features[0].properties, data.features[1].properties);
-      console.log('Constituency details API:',holder);
+  // Composing link to Official ECI candidates affidavits page: https://affidavit.eci.gov.in/showaffidavit/1/S13/34/PC
+  var ECIAffidavit_URL = `https://affidavit.eci.gov.in/showaffidavit/1/${ECI_code}/${String(tileFeatures.pc.properties.pc_no)}/PC`;
 
-      var ECI_code = ECILookup[String(holder.st_code)]['ECI_code'];
+  // Composing info
+  var info = `<span class='txt-light'>2019 Lok Sabha Elections</span><br>
+    <span class='txt-light'>Your Constituency: </span><b>${tileFeatures.pc.properties.pc_name}</b> (${tileFeatures.pc.properties.pc_no})<br>
+    <span class='txt-light'>Voting is on: </span><b>${tileFeatures.pc.properties['2019_election_date'].split('T')[0]}</b> (Phase ${tileFeatures.pc.properties['2019_election_phase']})<br>
+    <a href="${ECIAffidavit_URL}" target="_blank" class="link">Click here to see the Candidates</a> <br>
+    State: ${tileFeatures.pc.properties.st_name} (${ECI_code})<br>
+    `;
+  document.getElementById('infoPanel').classList.remove('loading');
+  document.getElementById('infoPanel').innerHTML = info;
 
-      // Composing link to Official ECI candidates affidavits page: https://affidavit.eci.gov.in/showaffidavit/1/S13/34/PC
-      var ECIAffidavit_URL = `https://affidavit.eci.gov.in/showaffidavit/1/${ECI_code}/${String(holder.pc_no)}/PC`;
+  // Clear previous and set the feature-state of the selected constieuncy feature id in the style layer as 'active'
+  map.removeFeatureState({
+    source: 'mapbox://planemad.3picr4b8',
+    sourceLayer: 'pc'
+  });
+  map.setFeatureState({
+    source: 'mapbox://planemad.3picr4b8',
+    sourceLayer: 'pc',
+    id: tileFeatures.pc.id
+  }, {
+    state: 'active'
+  });
 
-      // Composing info
-      var info = `<span class='txt-light'>2019 Lok Sabha Elections</span><br>
-      <span class='txt-light'>Your Constituency: </span><b>${holder.pc_name}</b> (${holder.pc_no})<br>
-      <span class='txt-light'>Voting is on: </span><b>${holder['2019_election_date'].split('T')[0]}</b> (Phase ${holder['2019_election_phase']})<br>
-      <a href="${ECIAffidavit_URL}" target="_blank" class="link">Click here to see the Candidates</a> <br>
-      State: ${holder.st_name} (${ECI_code})<br>
-      `;
-      document.getElementById('infoPanel').classList.remove('loading');
-      document.getElementById('infoPanel').innerHTML = info;
-
-      // Clear previous and set the feature-state of the selected constieuncy feature id in the style layer as 'active'
-      map.removeFeatureState({
-        source: 'mapbox://planemad.3picr4b8',
-        sourceLayer: 'pc'
-      });
-      map.setFeatureState({
-        source: 'mapbox://planemad.3picr4b8',
-        sourceLayer: 'pc',
-        id: data.features[1].id
-      }, {
-        state: 'active'
-      });
-
-    })
-    .catch(err => {
-      document.getElementById('infoPanel').classList.remove('loading');
-      document.getElementById('infoPanel').innerHTML = `Error while fetching data for that location`;
-    })
 }

--- a/js/show-data-at-point.js
+++ b/js/show-data-at-point.js
@@ -7,6 +7,12 @@ module.exports = showDataAtPoint
 
 function showDataAtPoint (map, e) {
 
+
+    // Query rendered features at clicked point
+    var features = map.queryRenderedFeatures(e.point,{layers:['pc fill mask']})
+    console.log(features)
+    console.log(e.point)
+
   // Add marker at clicked location
   Markers.addMarker(map, e);
   
@@ -27,6 +33,7 @@ function showDataAtPoint (map, e) {
   fetch(tilequeryURL)
     .then(response => response.json())
     .then(data => {
+      
       // merge the damn properies
       var holder = Object.assign({}, data.features[0].properties, data.features[1].properties);
       console.log('Constituency details API:',holder);


### PR DESCRIPTION
Fixes #27, #40 

Found that with on click mouse events, `e.features` will give the clicked features. We can take advantage of this and limit tilequery calls only for the first load and geolocation.

After this all mouse click query can completely skip calling the tilequery API. This gives instantaneous results from the loaded tiles.

![new2](https://user-images.githubusercontent.com/126868/55835461-d79a7c00-5b39-11e9-9963-7666b979c041.gif)
